### PR TITLE
Docker timeout

### DIFF
--- a/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
+++ b/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
@@ -35,7 +35,7 @@ public abstract class AbstractCompiler {
         System.out.println();
         String[] command = {"docker", "run", "--rm", "compile-io-image"};
         // ^ need to somehow edit this so that there is a timeout so loops don't run forever
-        executeAndDisplayOutput(command);
+        executeAndDisplayOutputWithTimeout(command, 60);
         System.out.println();
         System.out.println("Container has finished execution.");
         this.teardownDockerImage();
@@ -121,7 +121,11 @@ public abstract class AbstractCompiler {
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.inheritIO();
             Process proc = pb.start();
-            proc.waitFor(timeout, TimeUnit.SECONDS);
+            boolean procFinished = proc.waitFor(timeout, TimeUnit.SECONDS);
+            if (!procFinished) {
+                System.out.println("ERROR: Alotted execution time has elapsed. Process timed out.\n");
+                System.exit(0);
+            }
         } catch (IOException e) {
             e.printStackTrace();
             System.exit(1);
@@ -184,7 +188,11 @@ public abstract class AbstractCompiler {
                 System.out.print(line + "\n");
             }
     
-            proc.waitFor(timeout, TimeUnit.SECONDS);
+            boolean procFinished = proc.waitFor(timeout, TimeUnit.SECONDS);
+            if (!procFinished) {
+                System.out.println("ERROR: Alotted execution time has elapsed. Process timed out.\n");
+                System.exit(0);
+            }
         } catch (Exception e) {
             e.printStackTrace();
             System.out.println("ERROR: Failed to run the Docker container!\n");

--- a/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
+++ b/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
@@ -78,7 +78,7 @@ public abstract class AbstractCompiler {
      */
     public void teardownDockerfile() {
         System.out.println("Beginning teardown of Dockerfile...");
-        File dockerfile = new File(this.fileDirectory + "\\Dockerfile");
+        File dockerfile = new File(this.fileDirectory + "/Dockerfile");
         dockerfile.delete();
         System.out.println();
         System.out.println("Successfully removed the Dockerfile from " + this.fileDirectory);

--- a/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
+++ b/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
@@ -33,6 +33,7 @@ public abstract class AbstractCompiler {
         System.out.println("Attempting to run docker container...");
         System.out.println();
         String[] command = {"docker", "run", "--rm", "compile-io-image"};
+        // ^ need to somehow edit this so that there is a timeout so loops don't run forever
         executeAndDisplayOutput(command);
         System.out.println();
         System.out.println("Container has finished execution.");
@@ -75,7 +76,7 @@ public abstract class AbstractCompiler {
      */
     public void teardownDockerfile() {
         System.out.println("Beginning teardown of Dockerfile...");
-        File dockerfile = new File(this.fileDirectory + "/Dockerfile");
+        File dockerfile = new File(this.fileDirectory + "\\Dockerfile");
         dockerfile.delete();
         System.out.println();
         System.out.println("Successfully removed the Dockerfile from " + this.fileDirectory);

--- a/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
+++ b/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
@@ -27,15 +27,16 @@ public abstract class AbstractCompiler {
     /**
      * Creates and runs the container with the image name given to the constructor and prints the output to the console.
      * Removes the container created from the image after execution.
+     * @param long timeLimit A time limit for the process. Process terminates if runtime exceeds given timeLimit.
      * @return void
      * @throws Exception e
      */
-    public void run(){
+    public void run(long timeLimit){
         System.out.println("Attempting to run docker container...");
         System.out.println();
         String[] command = {"docker", "run", "--rm", "compile-io-image"};
         // ^ need to somehow edit this so that there is a timeout so loops don't run forever
-        executeAndDisplayOutputWithTimeout(command, 60);
+        executeAndDisplayOutputWithTimeout(command, timeLimit);
         System.out.println();
         System.out.println("Container has finished execution.");
         this.teardownDockerImage();
@@ -111,19 +112,20 @@ public abstract class AbstractCompiler {
      * Times out the process after surpassing the given time.
      * For details on the format of the parameter, see Java Docs on the ProcessBuilder object.
      * @param String[] command An array of strings representing a command line instruction
-     * @param long timeout 
+     * @param long timeLimit 
      * @return void
      * @throws IOException e
      * @throws InterruptedException e 
      */
-    public void executeCommandWithTimeout(String[] command, long timeout) {
+    public void executeCommandWithTimeout(String[] command, long timeLimit) {
         try {
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.inheritIO();
             Process proc = pb.start();
-            boolean procFinished = proc.waitFor(timeout, TimeUnit.SECONDS);
+            boolean procFinished = proc.waitFor(timeLimit, TimeUnit.SECONDS);
             if (!procFinished) {
                 System.out.println("ERROR: Alotted execution time has elapsed. Process timed out.\n");
+                System.out.println("Terminating process and exiting...");
                 System.exit(0);
             }
         } catch (IOException e) {
@@ -191,6 +193,7 @@ public abstract class AbstractCompiler {
             boolean procFinished = proc.waitFor(timeout, TimeUnit.SECONDS);
             if (!procFinished) {
                 System.out.println("ERROR: Alotted execution time has elapsed. Process timed out.\n");
+                System.out.println("Terminating process and exiting...");
                 System.exit(0);
             }
         } catch (Exception e) {

--- a/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
+++ b/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/AbstractCompiler.java
@@ -1,6 +1,7 @@
 package compile_io.docker;
 
 import java.io.*;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Abstract class for the compilers that builds and runs docker images.
@@ -106,6 +107,31 @@ public abstract class AbstractCompiler {
     }
 
     /**
+     * Executes the given command line argument. Displays no output to the console.
+     * Times out the process after surpassing the given time.
+     * For details on the format of the parameter, see Java Docs on the ProcessBuilder object.
+     * @param String[] command An array of strings representing a command line instruction
+     * @param long timeout 
+     * @return void
+     * @throws IOException e
+     * @throws InterruptedException e 
+     */
+    public void executeCommandWithTimeout(String[] command, long timeout) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(command);
+            pb.inheritIO();
+            Process proc = pb.start();
+            proc.waitFor(timeout, TimeUnit.SECONDS);
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.exit(1);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    /**
      * Executes the given command line argument and prints the output of the process to the console.
      * For details on the format of the parameter, see Java Docs on the ProcessBuilder object.
      * @param String[] command An array of strings representing a command line instruction
@@ -128,6 +154,37 @@ public abstract class AbstractCompiler {
             }
     
             proc.waitFor();
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("ERROR: Failed to run the Docker container!\n");
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Executes the given command line argument and prints the output of the process to the console.
+     * For details on the format of the parameter, see Java Docs on the ProcessBuilder object.
+     * @param String[] command An array of strings representing a command line instruction
+     * @param long timeout
+     * @return void
+     * @throws IOException e
+     * @throws InterruptedException e 
+     */
+    public void executeAndDisplayOutputWithTimeout(String[] command, long timeout) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder(command);
+            pb.inheritIO();
+            Process proc = pb.start();
+    
+            InputStream is = proc.getInputStream();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+
+            String line = "";
+            while ((line = reader.readLine()) != null) {
+                System.out.print(line + "\n");
+            }
+    
+            proc.waitFor(timeout, TimeUnit.SECONDS);
         } catch (Exception e) {
             e.printStackTrace();
             System.out.println("ERROR: Failed to run the Docker container!\n");

--- a/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/JavaCompiler.java
+++ b/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/JavaCompiler.java
@@ -34,7 +34,7 @@ public class JavaCompiler extends AbstractCompiler {
 
         try {
             System.out.println("Making Dockerfile in directory: " + super.getFileDirectory());
-            file = new File(super.getFileDirectory() + "/Dockerfile");
+            file = new File(super.getFileDirectory() + "\\Dockerfile");
             fos = new FileOutputStream(file);
       
             /* This logic will check whether the file

--- a/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/JavaCompiler.java
+++ b/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/JavaCompiler.java
@@ -34,7 +34,7 @@ public class JavaCompiler extends AbstractCompiler {
 
         try {
             System.out.println("Making Dockerfile in directory: " + super.getFileDirectory());
-            file = new File(super.getFileDirectory() + "\\Dockerfile");
+            file = new File(super.getFileDirectory() + "/Dockerfile");
             fos = new FileOutputStream(file);
       
             /* This logic will check whether the file

--- a/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/Main.java
+++ b/Spring_Server/gs-uploading-files-complete/src/main/java/compile_io/docker/Main.java
@@ -9,7 +9,7 @@ import java.io.*;
 public class Main {
     public static void main(String[] args){
         CompilerFactory compilerFactory = new CompilerFactory();
-        File file = new File("C:\\SCHOOL\\DockerTest\\RevEngDrunnable.jar");
+        File file = new File("C:\\SCHOOL\\DockerTest\\SimplePrint.jar");
         AbstractCompiler compiler = compilerFactory.getCompiler("java", file);
         compiler.createDockerfile();
         compiler.buildContainer();


### PR DESCRIPTION
run() now takes a parameter that sets a time limit (in seconds) for the docker container process. Recommended default is 60 seconds. Flexible parameter could let professors set a time limit themselves.