### PR TITLE
refactored test to account for change from josh PR for multifile

### DIFF
--- a/Spring_Server/gs-uploading-files-complete/src/test/java/compile_io/docker/JavaBuilderTest.java
+++ b/Spring_Server/gs-uploading-files-complete/src/test/java/compile_io/docker/JavaBuilderTest.java
@@ -74,6 +74,7 @@ public class JavaBuilderTest {
     dockerfileData.append("FROM gradle:4.3-jdk-alpine\n");
     dockerfileData.append("WORKDIR upload-dir\n");
     dockerfileData.append("EXPOSE 8000\n");
+    dockerfileData.append("USER root\n");
     dockerfileData.append("RUN mkdir -p src/main/java\n");
     dockerfileData.append("RUN mkdir -p src/test/java\n");
     dockerfileData.append("COPY build.gradle build.gradle\n");


### PR DESCRIPTION
# Addressed Issue(s)
#187 
# Goals
- Fix failing test caused by multifile PR that was on develop, but not on `docker-test-refactor`

# Special Considerations
- N/A

# Acceptance Criteria
- [ ] All JUnit tests pass

# Testing
- Navigate to `JavaBuilderTests.java` and run the tests

# Branch
`docker-refactor-two`
